### PR TITLE
Migrate Py2 cache without having to purge.

### DIFF
--- a/brink.sh
+++ b/brink.sh
@@ -464,6 +464,8 @@ copy_python() {
         # We have a Python, but we are not sure if is the right version.
         local version_file=${BUILD_FOLDER}/lib/PYTHIA_VERSION
 
+        # If we are upgrading the cache from Python 2,
+        # cat fails if this file is missing, so we create it blank.
         touch $version_file
         python_installed_version=`cat $version_file`
         if [ "$PYTHON_VERSION" != "$python_installed_version" ]; then

--- a/brink.sh
+++ b/brink.sh
@@ -464,6 +464,7 @@ copy_python() {
         # We have a Python, but we are not sure if is the right version.
         local version_file=${BUILD_FOLDER}/lib/PYTHIA_VERSION
 
+        touch $version_file
         python_installed_version=`cat $version_file`
         if [ "$PYTHON_VERSION" != "$python_installed_version" ]; then
             # We have a different python installed.


### PR DESCRIPTION
Scope
-----

I ran into the missing `/lib/PYTHIA_VERSION` on the GH runners [here](https://github.com/chevah/brink/pull/131/checks?check_run_id=2717290950). It seems it was not just pebkac :)


Changes
-------

I believe touching the `PYTHIA_VERSION` file lets us reuse the old Python 2 cache without having to `./brink.sh purge`, and that it updates as needed.

As such, I suggest adding the command in `brink.sh`.

Then again, this is my first PR here, and I just familiar enough with the script to be dangerous. So don't trust this PR!


Testing
-------

1. Check out a Python 2 version of a repository (for example, [brink on current master `de70366`](https://github.com/chevah/brink/commit/de70366265da71d6ed221d36387cbbaa6ca40057).
2. Do a `./brink.sh deps` to get the Py2 version of packages.
3. Check out a Py3 version of a repo (for example, the [`5648-py3-take2`](https://github.com/chevah/brink/tree/5648-py3-take2) branch).
4. Do a `./brink.sh deps` again, and see the `brink.sh` error. After this fix, it should work instead.
 