### PR TITLE
Update from py2 to py3.

### DIFF
--- a/brink.sh
+++ b/brink.sh
@@ -112,6 +112,10 @@ execute_venv() {
 # Called to update the dependencies inside the newly created virtual
 # environment.
 update_venv() {
+    # After updating the python version, the existing pyc files might no
+    # longer be valid.
+    _clean_pyc
+
     set +e
     ${PYTHON_BIN} -c 'from paver.tasks import main; main()' deps
     exit_code=$?
@@ -134,11 +138,6 @@ clean_build() {
     delete_folder ${DIST_FOLDER}
     echo "Removing publish..."
     delete_folder 'publish'
-    echo "Cleaning pyc files ..."
-
-    # Faster than '-exec rm {} \;' and supported in most OS'es,
-    # details at https://www.in-ulm.de/~mascheck/various/find/#xargs
-    find ./ -name '*.pyc' -exec rm {} +
 
     # In some case pip hangs with a build folder in temp and
     # will not continue until it is manually removed.
@@ -149,6 +148,15 @@ clean_build() {
     else
         rm -rf /tmp/pip*
     fi
+}
+
+
+_clean_pyc() {
+    echo "Cleaning pyc files ..."
+    # Faster than '-exec rm {} \;' and supported in most OS'es,
+    # details at https://www.in-ulm.de/~mascheck/various/find/#xargs
+    find ./ -name '*.pyc' -exec rm {} +
+
 }
 
 

--- a/pavement.py
+++ b/pavement.py
@@ -3,9 +3,7 @@
 """
 Build script for Python binary distribution.
 """
-import compileall
 import os
-import py_compile
 
 from brink.pavement_commons import (
     buildbot_list,
@@ -54,73 +52,6 @@ RUN_PACKAGES = [
     # Required for some unicode handling.
     'unidecode',
     ]
-
-
-def compile_file(fullname, ddir=None, force=0, rx=None, quiet=0):
-    """
-    <Byte-compile one file.
-
-    Arguments (only fullname is required):
-
-    fullname:  the file to byte-compile
-    ddir:      if given, the directory name compiled in to the
-               byte-code file.
-    force:     if 1, force compilation, even if timestamps are up-to-date
-    quiet:     if 1, be quiet during compilation
-    """
-    success = 1
-    name = os.path.basename(fullname)
-    if ddir is not None:
-        dfile = os.path.join(ddir, name)
-    else:
-        dfile = None
-    if rx is not None:
-        mo = rx.search(fullname)
-        if mo:
-            return success
-    if os.path.isfile(fullname):
-        tail = name[-3:]
-        if tail == '.py':
-            if not force:
-                try:
-                    mtime = int(os.stat(fullname).st_mtime)
-                    expect = struct.pack('<4sl', imp.get_magic(), mtime)
-                    cfile = fullname + (__debug__ and 'c' or 'o')
-                    with open(cfile, 'rb') as chandle:
-                        actual = chandle.read(8)
-                    if expect == actual:
-                        return success
-                except IOError:
-                    pass
-            if not quiet:
-                if isinstance(fullname, unicode):
-                    print_name = fullname.encode('utf-8')
-                else:
-                    print_name = fullname
-
-                print ('Compiling', print_name, '...')
-            try:
-                ok = py_compile.compile(fullname, None, dfile, True)
-            except py_compile.PyCompileError as err:
-                if quiet:
-                    if isinstance(fullname, unicode):
-                        print_name = fullname.encode('utf-8')
-                    else:
-                        print_name = fullname
-                    print('Compiling', print_name, '...')
-                print(err.msg.encode('utf-8'))
-                success = 0
-            except IOError, e:
-                print('Sorry', e)
-                success = 0
-            else:
-                if ok == 0:
-                    success = 0
-    return success
-
-
-# Path the upstream code.
-compileall.compile_file = compile_file
 
 
 @task


### PR DESCRIPTION
Scope
-----

This is a fix for the case when a py3 is updated on top of an existing py2 base code.
The problem is that py2 pyc files exist in the repo, and when migrating to py3 they are not updated (as they match the timestamp) but they will fail as they are not py3 bytecode.


Changes
-------

Remove pyc files after updating python.

As a drive by, also update to py3 brink  version.


Testing
-------

Manual update brink.conf to have a py2 version.
Get the python2 environment and make sure you have pavement.pyc file generated.
Update brink.conf to have have a py3 version.
Update the deps. The environment should be automatically updated.
You should not see any "bad magic number" errors.