### PR TITLE
Alpine 3.14 support.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -30,19 +30,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        container: [ 'alpine:3.12', 'centos:8.2.2004', 'centos:5.11' ]
+        container: [ 'alpine:3.14', 'centos:8.2.2004', 'centos:5.11' ]
     timeout-minutes: 30
     steps:
 
     # OpenSSL gets updated by apk, but that is the Alpine way, so it's fine.
-    - name: Alpine 3.12 setup
-      if: matrix.container == 'alpine:3.12'
+    - name: Alpine setup
+      if: startsWith(matrix.container, 'alpine')
       run: |
-        apk update
-        apk upgrade
-        apk add git curl bash openssh-client
-        curl -o /usr/local/bin/paxctl https://bin.chevah.com:20443/third-party-stuff/alpine/paxctl-3.12
-        chmod +x /usr/local/bin/paxctl
+        apk upgrade -U
+        apk add git curl bash openssh-client paxctl
 
     # Stick to CentOS 8.2 as OpenSSL got updated in 8.3 from 1.1.1c to 1.1.1g.
     - name: CentOS 8.2 setup

--- a/README.rst
+++ b/README.rst
@@ -22,19 +22,19 @@ Supported platforms
 -------------------
 
 * Windows Server 2012 R2 and newer (x86 and x64)
-* macOS 10.13 and newer.
+* macOS 10.13 and newer
 * all glibc-based Linux distributions (glibc 2.5+)
+* Alpine Linux 3.12 and newer.
 
 Platforms on which the system OpenSSL is used:
 
 * Red Hat Linux Enterprise 8 and newer (including derivatives such as CentOS)
-* Amazon Linux 2
 * Ubuntu Server 18.04 and 20.04
-* Alpine Linux 3.12
+* Alpine Linux
 
 Platforms that should work, but are not regularly tested:
 
-* FreeBSD 12
+* FreeBSD 12 and newer
 * OpenBSD 6.7 and newer
 * Solaris 11.4.
 

--- a/pkg_checks.sh
+++ b/pkg_checks.sh
@@ -22,7 +22,7 @@ RPM_PKGS="$BASE_PKGS tar diffutils \
     git-core openssl-devel zlib-devel libffi-devel ncurses-devel"
 # Alpine's ersatz tar/sha51sum binaries from Busybox are good enough.
 APK_PKGS="$BASE_PKGS file lddtree \
-    git openssl-dev zlib-dev libffi-dev musl-dev"
+    git openssl-dev zlib-dev libffi-dev musl-dev paxctl"
 # Windows is special, but package management is possible through Chocolatey.
 # Curl, sha512sum, and unzip are bundled with MINGW.
 CHOCO_PKGS=""
@@ -149,7 +149,8 @@ case "$OS" in
         execute $SUDO_CMD yum remove -y e2fsprogs-devel libuuid-devel
         ;;
     alpine*)
-        execute $SUDO_CMD apk del util-linux-dev
+        $CHECK_CMD util-linux-dev \
+            && execute $SUDO_CMD apk del util-linux-dev
         ;;
     *)
         (>&2 echo "Not guarding against linking to uuid libs on this system!")

--- a/src/Python/chevahbs
+++ b/src/Python/chevahbs
@@ -50,7 +50,7 @@ chevahbs_configure() {
     fi
 
     case $OS in
-        alpine312)
+        alpine312|alpine314)
             # Ugly hack for Python 3's configure issues.
             execute $SUDO_CMD rm -f /include
             execute $SUDO_CMD ln -s "${INSTALL_DIR}/include" /include


### PR DESCRIPTION
Scope
-----

Build on my Alpine 3.14 desktop installation.


Changes
-------

Minor fixes to support Alpine Linux 3.14.

Updated README.


Testing
-------

Run the automated tests.

Check the diffs.