### PR TITLE
Enable upstream Python tests.

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,7 +40,7 @@ jobs:
       if: startsWith(matrix.container, 'alpine')
       run: |
         apk upgrade -U
-        apk add git curl bash gcc make m4 automake libtool patch musl-dev linux-headers lddtree shadow sudo openssh-client file unzip g++
+        apk add git curl bash gcc make m4 automake libtool patch musl-dev linux-headers lddtree shadow sudo openssh-client file unzip g++ musl-locales
         apk del util-linux-dev
         curl --output /usr/local/bin/paxctl https://bin.chevah.com:20443/third-party-stuff/alpine/paxctl-3.12
         chmod +x /usr/local/bin/paxctl

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -40,7 +40,7 @@ jobs:
       if: startsWith(matrix.container, 'alpine')
       run: |
         apk upgrade -U
-        apk add git curl bash gcc make m4 automake libtool patch musl-dev linux-headers lddtree shadow sudo openssh-client file unzip
+        apk add git curl bash gcc make m4 automake libtool patch musl-dev linux-headers lddtree shadow sudo openssh-client file unzip g++
         apk del util-linux-dev
         curl --output /usr/local/bin/paxctl https://bin.chevah.com:20443/third-party-stuff/alpine/paxctl-3.12
         chmod +x /usr/local/bin/paxctl
@@ -49,7 +49,7 @@ jobs:
       if: startsWith(matrix.container, 'amazonlinux')
       run: |
         yum -y upgrade
-        yum -y install git-core gcc make m4 patch tar unzip perl perl-Test-Simple xz
+        yum -y install git-core gcc make m4 patch tar unzip perl perl-Test-Simple xz gcc-c++
 
     - name: Ubuntu setup
       if: startsWith(matrix.container, 'ubuntu')

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -32,7 +32,7 @@ jobs:
       matrix:
         # Alpine 3.12 has musl 1.1.24, Amazon 2 has glibc 2.26.
         container: [ 'alpine:3.12', 'amazonlinux:2' ]
-    timeout-minutes: 30
+    timeout-minutes: 45
     steps:
 
     # OpenSSL gets updated by apk, but that is the Alpine way, so it's fine.
@@ -40,7 +40,7 @@ jobs:
       if: startsWith(matrix.container, 'alpine')
       run: |
         apk upgrade -U
-        apk add git curl bash gcc make m4 automake libtool patch musl-dev linux-headers lddtree shadow sudo openssh-client file unzip g++ musl-locales
+        apk add git curl bash gcc make m4 automake libtool patch musl-dev linux-headers lddtree shadow sudo openssh-client file unzip g++ musl-locales dejagnu
         apk del util-linux-dev
         curl --output /usr/local/bin/paxctl https://bin.chevah.com:20443/third-party-stuff/alpine/paxctl-3.12
         chmod +x /usr/local/bin/paxctl
@@ -49,14 +49,14 @@ jobs:
       if: startsWith(matrix.container, 'amazonlinux')
       run: |
         yum -y upgrade
-        yum -y install git-core gcc make m4 patch tar unzip perl perl-Test-Simple xz gcc-c++
+        yum -y install git-core gcc make m4 patch tar unzip perl perl-Test-Simple xz gcc-c++ dejagnu
 
     - name: Ubuntu setup
       if: startsWith(matrix.container, 'ubuntu')
       run: |
         apt update
         apt --yes dist-upgrade
-        apt --yes install wget curl gcc make m4 automake libtool patch sudo openssh-client unzip git libtest-simple-perl
+        apt --yes install wget curl gcc make m4 automake libtool patch sudo openssh-client unzip git libtest-simple-perl xz-utils g++ dejagnu
 
     - name: Clone repo independently
       run: |

--- a/build.conf
+++ b/build.conf
@@ -5,10 +5,6 @@
 BUILD_DIR="build"
 # This is also defined independently in "publish_dist.sh".
 DIST_DIR="dist"
-# Bash arrays are not exported to child processes. More details at
-# https://www.mail-archive.com/bug-bash@gnu.org/msg01774.html.
-# Therefore, put them into a file to be sourced by "chevahbs" scripts.
-export BUILD_ENV_ARRAYS_FILE="BUILD_ENV_ARRAYS"
 
 # Python and lib versions.
 PYTHON_BUILD_VERSION="3.11.3"

--- a/build.sh
+++ b/build.sh
@@ -241,12 +241,11 @@ command_test() {
     execute "$python_binary" -m pip install "${PIP_ARGS[@]}" \
         safety=="$SAFETY_VERSION"
     execute "$python_binary" -m safety check --full-report
+    execute popd
     echo "::endgroup::"
 
     echo "#### Executing Chevah shell tests... ####"
-    ./src/chevah-bash-tests/shellcheck_tests.sh
-
-    execute popd
+    execute ./src/chevah-bash-tests/shellcheck_tests.sh
 }
 
 

--- a/build.sh
+++ b/build.sh
@@ -49,6 +49,8 @@ PYTHON_BIN="$INSTALL_DIR/bin/$PYTHON_VERSION"
 # Explicitly choose the C compiler in order to make it possible to switch
 # between native compilers and GCC on platforms such as the BSDs and Solaris.
 export CC="gcc"
+# Used for testing Python C++ extensions (test_cppext).
+export CXX="g++"
 # Other needed tools (GNU flavours preferred).
 # For proper quoting, _CMD vars are Bash arrays of commands and optional flags.
 MAKE_CMD=(make)

--- a/functions_build.sh
+++ b/functions_build.sh
@@ -91,12 +91,10 @@ chevahbs_build() {
 }
 
 chevahbs_test() {
-    echo "## Testing... ##"
     chevahbs_try "$@"
 }
 
 chevahbs_install() {
-    echo "## Installing... ##"
     chevahbs_cp "$@"
 }
 
@@ -110,7 +108,7 @@ build() {
     project_name="$1"
     # Second parameter has the form: "3.2.1", "1.1.1t", "3410200", etc.
     project_ver="$2"
-    echo "::group::Build" "$@"
+    echo "::group::" "$1" "build"
     echo "#### Building $1 version $2... ####"
 
     # This is where sources are unpacked, patched, and built.
@@ -145,12 +143,12 @@ build() {
     execute ./chevahbs build "$OS" "$install_dir" "$project_ver"
     echo "::endgroup::"
 
-    echo "::group::Test" "$@"
+    echo "::group::" "$1" "test"
     echo "#### Testing $1 version $2... ####"
     execute ./chevahbs test "$OS"
     echo "::endgroup::"
 
-    echo "::group::Install" "$@"
+    echo "::group::" "$1" "install"
     echo "#### Installing $1 version $2... ####"
     execute ./chevahbs install "$OS" "$install_dir"
     if [ -e "Makefile" ]; then

--- a/functions_build.sh
+++ b/functions_build.sh
@@ -88,10 +88,17 @@ chevahbs_build() {
     chevahbs_configure "$@"
     echo "## Compiling... ##"
     chevahbs_compile "$@"
-    echo "## Installing... ##"
-    chevahbs_install "$@"
 }
 
+chevahbs_test() {
+    echo "## Testing... ##"
+    chevahbs_try "$@"
+}
+
+chevahbs_install() {
+    echo "## Installing... ##"
+    chevahbs_cp "$@"
+}
 
 #
 # Build-related stuff.
@@ -136,15 +143,25 @@ build() {
     # The actual build happens here.
     execute pushd "$own_build_dir"
     execute ./chevahbs build "$OS" "$install_dir" "$project_ver"
-        if [ -e "Makefile" ]; then
-            lib_config_dir="$install_dir/lib/config"
-            makefile_name="Makefile.$OS.$version_dir"
-            execute mkdir -p "$lib_config_dir"
-            execute cp Makefile "$lib_config_dir/$makefile_name"
-        fi
-    execute popd
-
     echo "::endgroup::"
+
+    echo "::group::Test" "$@"
+    echo "#### Testing $1 version $2... ####"
+    execute ./chevahbs test "$OS"
+    echo "::endgroup::"
+
+    echo "::group::Install" "$@"
+    echo "#### Installing $1 version $2... ####"
+    execute ./chevahbs install "$OS" "$install_dir"
+    if [ -e "Makefile" ]; then
+        lib_config_dir="$install_dir/lib/config"
+        makefile_name="Makefile.$OS.$version_dir"
+        execute mkdir -p "$lib_config_dir"
+        execute cp Makefile "$lib_config_dir/$makefile_name"
+    fi
+    echo "::endgroup::"
+
+    execute popd
 }
 
 

--- a/functions_build.sh
+++ b/functions_build.sh
@@ -157,9 +157,8 @@ build() {
         execute mkdir -p "$lib_config_dir"
         execute cp Makefile "$lib_config_dir/$makefile_name"
     fi
-    echo "::endgroup::"
-
     execute popd
+    echo "::endgroup::"
 }
 
 

--- a/functions_build.sh
+++ b/functions_build.sh
@@ -108,7 +108,7 @@ build() {
     project_name="$1"
     # Second parameter has the form: "3.2.1", "1.1.1t", "3410200", etc.
     project_ver="$2"
-    echo "::group::" "$1" "build"
+    echo "::group::" "$1 $2" "build"
     echo "#### Building $1 version $2... ####"
 
     # This is where sources are unpacked, patched, and built.
@@ -143,12 +143,12 @@ build() {
     execute ./chevahbs build "$OS" "$install_dir" "$project_ver"
     echo "::endgroup::"
 
-    echo "::group::" "$1" "test"
+    echo "::group::" "$1 $2" "test"
     echo "#### Testing $1 version $2... ####"
     execute ./chevahbs test "$OS"
     echo "::endgroup::"
 
-    echo "::group::" "$1" "install"
+    echo "::group::" "$1 $2" "install"
     echo "#### Installing $1 version $2... ####"
     execute ./chevahbs install "$OS" "$install_dir"
     if [ -e "Makefile" ]; then

--- a/pkg_checks.sh
+++ b/pkg_checks.sh
@@ -7,6 +7,7 @@
 #   * build tools: make, m4 (same as above)
 #   * patch (for applying patches from src/, these can be hotfixes to .py files)
 #   * git (for patching Python's version, if building Python)
+#   * a C++ compiler for testing Python C++ extensions (test_cppext).
 #   * automake, libtool, headers of a curses library (if building libedit)
 #   * perl 5.10.0 or newer, Test::More 0.96 or newer (if building OpenSSL)
 #   * curl, sha512sum, tar, unzip (for downloading and unpacking)

--- a/src/Python-Windows/chevahbs
+++ b/src/Python-Windows/chevahbs
@@ -8,7 +8,7 @@
 # The relative paths work in both src/blabla and build/blabla.
 source ../../functions.sh
 source ../../functions_build.sh
-source ../../"$BUILD_ENV_ARRAYS_FILE"
+source ../../"BUILD_ENV_ARRAYS"
 
 # The usual two arguments, e.g. "Python" and "3.9.0",
 # but the installation path is also needed, because this script is special.

--- a/src/Python/chevahbs
+++ b/src/Python/chevahbs
@@ -79,13 +79,15 @@ chevahbs_configure() {
 
 chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
+
     if [ "$OS" = "macos" ]; then
-        # Extra CA certs are needed to pass test_cppext and test_distutils.
-        execute sed s#/Library/Frameworks/Python.framework/Versions/@PYVER@/bin/python@PYVER@#"$PYTHON_BIN"# Mac/BuildScript/resources/install_certificates.command > install_certificates.command
-        execute /bin/sh ./install_certificates.command
-    fi
-    if [ "$OS" != "linux_musl" ]; then
+        # Extra CA certs needed to pass test_cppext/test_distutils, and included
+        # Mac/BuildScript/resources/install_certificates.command fix is broken.
+        (>&2 echo -e "\tNot running Python upstream tests on macOS.")
+    elif [ "$OS" = "linux_musl" ]; then
         # Locales not supported on Alpine 3.12, failing locale-related tests.
+        (>&2 echo -e "\tNot running Python upstream tests on musl-based Linux.")
+    else
         execute "${MAKE_CMD[@]}" test
     fi
 }

--- a/src/Python/chevahbs
+++ b/src/Python/chevahbs
@@ -79,7 +79,9 @@ chevahbs_configure() {
 
 chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
+}
 
+chevahbs_try() {
     if [ "$OS" = "macos" ]; then
         # Extra CA certs needed to pass test_cppext/test_distutils, and included
         # Mac/BuildScript/resources/install_certificates.command fix is broken.
@@ -93,7 +95,7 @@ chevahbs_compile() {
 }
 
 
-chevahbs_install() {
+chevahbs_cp() {
     if [ "$OS" = "linux_musl" ]; then
         # EMUTRAMP required for full functionality under a grsec kernel.
         # Don't use "paxmark", file attributes will be lost when tar'ed.

--- a/src/Python/chevahbs
+++ b/src/Python/chevahbs
@@ -8,7 +8,7 @@
 # The relative paths work in both src/blabla and build/blabla.
 source ../../functions.sh
 source ../../functions_build.sh
-source ../../"$BUILD_ENV_ARRAYS_FILE"
+source ../../BUILD_ENV_ARRAYS
 
 
 chevahbs_getsources() {

--- a/src/Python/chevahbs
+++ b/src/Python/chevahbs
@@ -79,8 +79,7 @@ chevahbs_configure() {
 
 chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
-    # Don't use execute below, some tests might fail innocuously.
-    "${MAKE_CMD[@]}" test
+    execute "${MAKE_CMD[@]}" test
 }
 
 

--- a/src/Python/chevahbs
+++ b/src/Python/chevahbs
@@ -79,9 +79,8 @@ chevahbs_configure() {
 
 chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
-    # FIXME:12: Enable Python's own tests again.
     # Don't use execute below, some tests might fail innocuously.
-    # execute "${MAKE_CMD[@]}" test
+    "${MAKE_CMD[@]}" test
 }
 
 

--- a/src/Python/chevahbs
+++ b/src/Python/chevahbs
@@ -79,8 +79,13 @@ chevahbs_configure() {
 
 chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
-    # Locales not fully supported on Alpine 3.12, failing locale-related tests.
+    if [ "$OS" = "macos" ]; then
+        # Extra CA certs are needed to pass test_cppext and test_distutils.
+        execute sed s#/Library/Frameworks/Python.framework/Versions/@PYVER@/bin/python@PYVER@#"$PYTHON_BIN"# Mac/BuildScript/resources/install_certificates.command > install_certificates.command
+        execute /bin/sh ./install_certificates.command
+    fi
     if [ "$OS" != "linux_musl" ]; then
+        # Locales not supported on Alpine 3.12, failing locale-related tests.
         execute "${MAKE_CMD[@]}" test
     fi
 }

--- a/src/Python/chevahbs
+++ b/src/Python/chevahbs
@@ -79,20 +79,21 @@ chevahbs_configure() {
 
 chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
-    execute "${MAKE_CMD[@]}" test
+    # Locales not fully supported on Alpine 3.12, failing locale-related tests.
+    if [ "$OS" != "linux_musl" ]; then
+        execute "${MAKE_CMD[@]}" test
+    fi
 }
 
 
 chevahbs_install() {
-    case "$OS" in
-        alpine*)
-            # EMUTRAMP required for full functionality under a grsec kernel.
-            # Don't use "paxmark", file attributes will be lost when tar'ed.
-            # Needed with non-grsec kernels as well, otherwise PAM-related
-            # compat tests crash with signal 11 (last tested on Alpine 3.12).
-            execute paxctl -cE python
-            ;;
-    esac
+    if [ "$OS" = "linux_musl" ]; then
+        # EMUTRAMP required for full functionality under a grsec kernel.
+        # Don't use "paxmark", file attributes will be lost when tar'ed.
+        # Needed with non-grsec kernels as well, otherwise PAM-related
+        # compat tests crash with signal 11 (last tested on Alpine 3.12).
+        execute paxctl -cE python
+    fi
 
     execute "${MAKE_CMD[@]}" install
 }

--- a/src/bzip2/chevahbs
+++ b/src/bzip2/chevahbs
@@ -36,8 +36,12 @@ chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
 }
 
+chevahbs_try() {
+    execute "${MAKE_CMD[@]}" test
+}
 
-chevahbs_install() {
+
+chevahbs_cp() {
     # bzip2's installation copies too many files, let's do it manually.
     execute cp bzlib.h "$INSTALL_DIR"/include/ 
     execute cp libbz2.a "$INSTALL_DIR"/lib/ 

--- a/src/bzip2/chevahbs
+++ b/src/bzip2/chevahbs
@@ -6,7 +6,7 @@
 # The relative paths work in both src/blabla and build/blabla.
 source ../../functions.sh
 source ../../functions_build.sh
-source ../../"$BUILD_ENV_ARRAYS_FILE"
+source ../../"BUILD_ENV_ARRAYS"
 
 
 chevahbs_getsources() {

--- a/src/chevah-bash-tests/shellcheck_tests.sh
+++ b/src/chevah-bash-tests/shellcheck_tests.sh
@@ -38,9 +38,9 @@ exec_sh_files=()
 other_sh_files=()
 for sh_file in ./*.sh; do
     if [ -x "$sh_file" ]; then
-        exec_sh_files=("${exec_sh_files[@]}" "$sh_file")
+        exec_sh_files+=("$sh_file")
     else
-        other_sh_files=("${other_sh_files[@]}" "$sh_file")
+        other_sh_files+=("$sh_file")
     fi
 done
 echo "Executable shell scripts to be checked (including their sources):"

--- a/src/libedit/chevahbs
+++ b/src/libedit/chevahbs
@@ -5,7 +5,7 @@
 # Import shared code.
 source ../../functions.sh
 source ../../functions_build.sh
-source ../../"$BUILD_ENV_ARRAYS_FILE"
+source ../../"BUILD_ENV_ARRAYS"
 
 
 chevahbs_getsources() {

--- a/src/libedit/chevahbs
+++ b/src/libedit/chevahbs
@@ -51,7 +51,7 @@ chevahbs_compile() {
 }
 
 
-chevahbs_install() {
+chevahbs_cp() {
     execute "${MAKE_CMD[@]}" install DESTDIR="$INSTALL_DIR"
 }
 

--- a/src/libffi/chevahbs
+++ b/src/libffi/chevahbs
@@ -30,8 +30,13 @@ chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
 }
 
+# This requires DejaGnu to actually do the tests.
+chevahbs_try() {
+    execute "${MAKE_CMD[@]}" check
+}
 
-chevahbs_install() {
+
+chevahbs_cp() {
     case "$OS" in
         linux*)
             echo "Installing manually to avoid messing with a lib64/ sub-dir:"

--- a/src/libffi/chevahbs
+++ b/src/libffi/chevahbs
@@ -32,6 +32,15 @@ chevahbs_compile() {
 
 # This requires DejaGnu to actually do the tests.
 chevahbs_try() {
+    # Tests fail on Amazon 2: https://github.com/libffi/libffi/issues/785.
+    if [ "$OS" = "linux" ]; then
+        if [ -f /etc/os-release ]; then
+            if grep -q ^'PRETTY_NAME="Amazon Linux 2"'$ /etc/os-release; then
+                (>&2 echo -e "\tSkipping libffi tests on Amazon Linux 2.")
+                return
+            fi
+        fi
+    fi
     execute "${MAKE_CMD[@]}" check
 }
 

--- a/src/libffi/chevahbs
+++ b/src/libffi/chevahbs
@@ -6,7 +6,7 @@
 # The relative paths work in both src/blabla and build/blabla.
 source ../../functions.sh
 source ../../functions_build.sh
-source ../../"$BUILD_ENV_ARRAYS_FILE"
+source ../../"BUILD_ENV_ARRAYS"
 
 
 chevahbs_getsources() {

--- a/src/openssl/chevahbs
+++ b/src/openssl/chevahbs
@@ -6,7 +6,7 @@
 # The relative paths work in both src/blabla and build/blabla.
 source ../../functions.sh
 source ../../functions_build.sh
-source ../../"$BUILD_ENV_ARRAYS_FILE"
+source ../../"BUILD_ENV_ARRAYS"
 
 
 chevahbs_getsources() {

--- a/src/openssl/chevahbs
+++ b/src/openssl/chevahbs
@@ -30,11 +30,15 @@ chevahbs_configure() {
 
 chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
+}
+
+
+chevahbs_try() {
     execute "${MAKE_CMD[@]}" test
 }
 
 
-chevahbs_install() {
+chevahbs_cp() {
     case "$OS" in
         linux*)
             echo "Installing manually to avoid messing with a lib64/ sub-dir:"

--- a/src/sqlite-autoconf/chevahbs
+++ b/src/sqlite-autoconf/chevahbs
@@ -33,7 +33,14 @@ chevahbs_compile() {
 }
 
 
-chevahbs_install() {
+# FIXME:48:
+# Test SQLite when building it from source.
+chevahbs_try() {
+    execute "${MAKE_CMD[@]}" check
+}
+
+
+chevahbs_cp() {
     execute "${MAKE_CMD[@]}" install DESTDIR="$INSTALL_DIR"
 }
 

--- a/src/sqlite-autoconf/chevahbs
+++ b/src/sqlite-autoconf/chevahbs
@@ -6,7 +6,7 @@
 # The relative paths work in both src/blabla and build/blabla.
 source ../../functions.sh
 source ../../functions_build.sh
-source ../../"$BUILD_ENV_ARRAYS_FILE"
+source ../../"BUILD_ENV_ARRAYS"
 
 
 chevahbs_getsources() {

--- a/src/xz/chevahbs
+++ b/src/xz/chevahbs
@@ -31,7 +31,12 @@ chevahbs_compile() {
 }
 
 
-chevahbs_install() {
+chevahbs_try() {
+    execute "${MAKE_CMD[@]}" check
+}
+
+
+chevahbs_cp() {
     execute "${MAKE_CMD[@]}" install DESTDIR="$INSTALL_DIR"
 }
 

--- a/src/xz/chevahbs
+++ b/src/xz/chevahbs
@@ -6,7 +6,7 @@
 # The relative paths work in both src/blabla and build/blabla.
 source ../../functions.sh
 source ../../functions_build.sh
-source ../../"$BUILD_ENV_ARRAYS_FILE"
+source ../../"BUILD_ENV_ARRAYS"
 
 
 chevahbs_getsources() {

--- a/src/zlib/chevahbs
+++ b/src/zlib/chevahbs
@@ -30,8 +30,11 @@ chevahbs_compile() {
     execute "${MAKE_CMD[@]}"
 }
 
+chevahbs_try() {
+    execute "${MAKE_CMD[@]}" test
+}
 
-chevahbs_install() {
+chevahbs_cp() {
     execute "${MAKE_CMD[@]}" install DESTDIR="$INSTALL_DIR"
 }
 

--- a/src/zlib/chevahbs
+++ b/src/zlib/chevahbs
@@ -6,7 +6,7 @@
 # The relative paths work in both src/blabla and build/blabla.
 source ../../functions.sh
 source ../../functions_build.sh
-source ../../"$BUILD_ENV_ARRAYS_FILE"
+source ../../"BUILD_ENV_ARRAYS"
 
 
 chevahbs_getsources() {


### PR DESCRIPTION
Scope
-----

Fixes #12 


Changes
-------

Enabled the Python tests on the platforms where we build it, with the exception of:
- [x] Alpine Linux
- [x] macOS.

**Drive-by fixes**:
  - fixed enabling EMUTRAMP on Alpine with `paxctl`.
  - fixed the execution of Shellcheck tests.
  - fixed minor Shellcheck warnings.
  - use dedicated `chevabs` functions for testing and installing to have them listed distinctly in GHA output. 
  - enabled upstream tests for `libffi`, `bzip2`, `xz`, `zlib`.

Testing
-------

Automated.
