### PR TITLE
[#47] Re-enable `compat` tests.

### DIFF
--- a/.github/workflows/bare.yaml
+++ b/.github/workflows/bare.yaml
@@ -42,6 +42,8 @@ jobs:
 
     - name: Test compat
       timeout-minutes: 5
+      env:
+        CODECOV_TOKEN: "local"
       run: bash ./build.sh compat
 
     # Commit changed requirements.txt back to the repository
@@ -133,6 +135,8 @@ jobs:
 
     - name: Test compat
       timeout-minutes: 5
+      env:
+        CODECOV_TOKEN: "local"
       run: ./build.sh compat
 
     - name: Upload testing package
@@ -171,6 +175,8 @@ jobs:
 
     - name: Test compat
       timeout-minutes: 5
+      env:
+        CODECOV_TOKEN: "local"
       run: ./build.sh compat
 
     - name: Upload testing package

--- a/.github/workflows/bare.yaml
+++ b/.github/workflows/bare.yaml
@@ -43,7 +43,7 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
-        CODECOV_TOKEN: "local"
+        CODECOV_TOKEN: local
       run: bash ./build.sh compat
 
     # Commit changed requirements.txt back to the repository
@@ -136,7 +136,7 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
-        CODECOV_TOKEN: "local"
+        CODECOV_TOKEN: local
       run: ./build.sh compat
 
     - name: Upload testing package
@@ -176,7 +176,7 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
-        CODECOV_TOKEN: "local"
+        CODECOV_TOKEN: local
       run: ./build.sh compat
 
     - name: Upload testing package

--- a/.github/workflows/bare.yaml
+++ b/.github/workflows/bare.yaml
@@ -137,7 +137,6 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
-        USER: runneradmin
         CODECOV_TOKEN: local
       run: ./build.sh compat
 
@@ -178,7 +177,6 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
-        USER: runneradmin
         CODECOV_TOKEN: local
       run: ./build.sh compat
 

--- a/.github/workflows/bare.yaml
+++ b/.github/workflows/bare.yaml
@@ -14,6 +14,9 @@ concurrency:
   group: bare-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CI: 'true'
+
 jobs:
   windows:
     # The type of runner that the job will run on

--- a/.github/workflows/bare.yaml
+++ b/.github/workflows/bare.yaml
@@ -40,6 +40,10 @@ jobs:
       timeout-minutes: 5
       run: bash ./build.sh test
 
+    - name: Test compat
+      timeout-minutes: 5
+      run: bash ./build.sh compat
+
     # Commit changed requirements.txt back to the repository
     - uses: chevah/git-auto-commit-action@HEAD
       with:
@@ -127,6 +131,10 @@ jobs:
       timeout-minutes: 5
       run: ./build.sh test
 
+    - name: Test compat
+      timeout-minutes: 5
+      run: ./build.sh compat
+
     - name: Upload testing package
       timeout-minutes: 5
       run: |
@@ -160,6 +168,10 @@ jobs:
     - name: Test Pythia
       timeout-minutes: 5
       run: ./build.sh test
+
+    - name: Test compat
+      timeout-minutes: 5
+      run: ./build.sh compat
 
     - name: Upload testing package
       timeout-minutes: 5

--- a/.github/workflows/bare.yaml
+++ b/.github/workflows/bare.yaml
@@ -44,7 +44,7 @@ jobs:
       run: bash ./build.sh test
 
     - name: Test compat
-      timeout-minutes: 5
+      timeout-minutes: 10
       env:
         USER: runneradmin
         CODECOV_TOKEN: local
@@ -138,7 +138,7 @@ jobs:
       run: ./build.sh test
 
     - name: Test compat
-      timeout-minutes: 5
+      timeout-minutes: 10
       env:
         CODECOV_TOKEN: local
       run: ./build.sh compat
@@ -178,7 +178,7 @@ jobs:
       run: ./build.sh test
 
     - name: Test compat
-      timeout-minutes: 5
+      timeout-minutes: 10
       env:
         CODECOV_TOKEN: local
       run: ./build.sh compat

--- a/.github/workflows/bare.yaml
+++ b/.github/workflows/bare.yaml
@@ -43,6 +43,7 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
+        USER: runneradmin
         CODECOV_TOKEN: local
       run: bash ./build.sh compat
 
@@ -136,6 +137,7 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
+        USER: runneradmin
         CODECOV_TOKEN: local
       run: ./build.sh compat
 
@@ -176,6 +178,7 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
+        USER: runneradmin
         CODECOV_TOKEN: local
       run: ./build.sh compat
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -77,6 +77,12 @@ jobs:
         cd pythia
         ./build.sh test
 
+    - name: Test compat
+      timeout-minutes: 5
+      run: |
+        cd pythia
+        ./build.sh compat
+
     # Using `~/` is problematic under Docker, use `/root/`.
     # Remove key in same step to avoid leaving it on disk if publishing fails.
     - name: Upload testing package

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,9 +34,9 @@ jobs:
     - name: Alpine setup
       if: startsWith(matrix.container, 'alpine')
       run: |
-        apk upgrade -U
-        apk add git curl bash gcc make m4 patch musl-dev linux-headers lddtree shadow openssh-client file unzip perl g++ musl-locales dejagnu
-        apk del util-linux-dev
+        /sbin/apk upgrade -U
+        /sbin/apk add git curl bash gcc make m4 patch musl-dev linux-headers lddtree shadow openssh-client file unzip perl g++ musl-locales dejagnu
+        /sbin/apk del util-linux-dev
         curl --output /usr/local/bin/paxctl https://bin.chevah.com:20443/third-party-stuff/alpine/paxctl-3.12
         chmod +x /usr/local/bin/paxctl
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -15,6 +15,8 @@ concurrency:
   group: docker-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CI: 'true'
 
 # Using a job name that doesn't contain the OS name, to minimize the risk of
 # confusion with the OS names of the containers, which are the relevant ones.

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,22 +59,28 @@ jobs:
         apt --yes dist-upgrade
         apt --yes install wget curl gcc make m4 patch openssh-client unzip git libtest-simple-perl xz-utils g++ dejagnu
 
+    - name: Clone repo independently
+       run: |
+        git clone https://github.com/chevah/pythia.git
+        cd pythia
+        git checkout ${GITHUB_HEAD_REF}
+
     - name: Chevah user setup
       run: |
         useradd -g adm -s /bin/bash -m chevah
         echo '%adm    ALL=NOPASSWD: ALL' > /etc/sudoers
 
-    - uses: actions/checkout@v4
-
     - name: Build Pythia
       timeout-minutes: 30
       run: |
-        chown -R chevah .
+        chown -R chevah pythia
+        cd pythia
         su chevah -c "./build.sh build"
 
     - name: Test Pythia
       timeout-minutes: 5
       run: |
+        cd pythia
         su chevah -c "./build.sh test"
 
     - name: Test compat
@@ -82,6 +88,7 @@ jobs:
       env:
         CODECOV_TOKEN: local
       run: |
+        cd pythia
         su chevah -c "./build.sh compat"
 
     # Using `~/` is problematic under Docker, use `/root/`.

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -80,7 +80,7 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
-        CODECOV_TOKEN: "local"
+        CODECOV_TOKEN: local
       run: |
         cd pythia
         ./build.sh compat

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -37,8 +37,8 @@ jobs:
         apk upgrade -U
         apk add git curl bash gcc make m4 patch musl-dev linux-headers lddtree shadow openssh-client file unzip perl g++ musl-locales dejagnu
         apk del util-linux-dev
-        curl --output /usr/local/bin/paxctl https://bin.chevah.com:20443/third-party-stuff/alpine/paxctl-3.12
-        chmod +x /usr/local/bin/paxctl
+        curl --output /usr/bin/paxctl https://bin.chevah.com:20443/third-party-stuff/alpine/paxctl-3.12
+        chmod +x /usr/bin/paxctl
 
     - name: Amazon setup
       if: startsWith(matrix.container, 'amazonlinux')

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -34,9 +34,9 @@ jobs:
     - name: Alpine setup
       if: startsWith(matrix.container, 'alpine')
       run: |
-        /sbin/apk upgrade -U
-        /sbin/apk add git curl bash gcc make m4 patch musl-dev linux-headers lddtree shadow openssh-client file unzip perl g++ musl-locales dejagnu
-        /sbin/apk del util-linux-dev
+        apk upgrade -U
+        apk add git curl bash gcc make m4 patch musl-dev linux-headers lddtree shadow openssh-client file unzip perl g++ musl-locales dejagnu
+        apk del util-linux-dev
         curl --output /usr/local/bin/paxctl https://bin.chevah.com:20443/third-party-stuff/alpine/paxctl-3.12
         chmod +x /usr/local/bin/paxctl
 

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -35,7 +35,7 @@ jobs:
       if: startsWith(matrix.container, 'alpine')
       run: |
         apk upgrade -U
-        apk add git curl bash gcc make m4 patch musl-dev linux-headers lddtree shadow openssh-client file unzip perl g++ musl-locales dejagnu
+        apk add git curl bash gcc make m4 patch musl-dev linux-headers lddtree shadow openssh-client file unzip perl g++ musl-locales dejagnu sudo
         apk del util-linux-dev
         curl --output /usr/bin/paxctl https://bin.chevah.com:20443/third-party-stuff/alpine/paxctl-3.12
         chmod +x /usr/bin/paxctl
@@ -44,7 +44,7 @@ jobs:
       if: startsWith(matrix.container, 'amazonlinux')
       run: |
         yum -y upgrade
-        yum -y install git-core gcc make m4 patch tar unzip perl perl-Test-Simple perl-IPC-Cmd xz gcc-c++ dejagnu bzip2
+        yum -y install git-core gcc make m4 patch tar unzip perl perl-Test-Simple perl-IPC-Cmd xz gcc-c++ dejagnu bzip2 sudo
         # To avoid linking against libdb and gdmb libraries on Amazon Linux 2.
         # Can't simply uninstall libdb-devel and gdmb-devel, they are required by perl-IPC-Cmd.
         rm -v /usr/include/libdb/db.h
@@ -57,7 +57,7 @@ jobs:
       run: |
         apt update
         apt --yes dist-upgrade
-        apt --yes install wget curl gcc make m4 patch openssh-client unzip git libtest-simple-perl xz-utils g++ dejagnu
+        apt --yes install wget curl gcc make m4 patch openssh-client unzip git libtest-simple-perl xz-utils g++ dejagnu sudo
 
     # actions/checkout doesn't work on Amazon Linux 2, requires glibc 2.27.
     - name: Clone repo independently

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -87,7 +87,7 @@ jobs:
         su chevah -c "./build.sh test"
 
     - name: Test compat
-      timeout-minutes: 5
+      timeout-minutes: 10
       env:
         USER: chevah
         CODECOV_TOKEN: local

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -87,6 +87,7 @@ jobs:
     - name: Test compat
       timeout-minutes: 5
       env:
+        USER: chevah
         CODECOV_TOKEN: local
       run: |
         cd pythia

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -79,6 +79,8 @@ jobs:
 
     - name: Test compat
       timeout-minutes: 5
+      env:
+        CODECOV_TOKEN: "local"
       run: |
         cd pythia
         ./build.sh compat

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,8 +59,9 @@ jobs:
         apt --yes dist-upgrade
         apt --yes install wget curl gcc make m4 patch openssh-client unzip git libtest-simple-perl xz-utils g++ dejagnu
 
+    # actions/checkout doesn't work on Amazon Linux 2, requires glibc 2.27.
     - name: Clone repo independently
-       run: |
+      run: |
         git clone https://github.com/chevah/pythia.git
         cd pythia
         git checkout ${GITHUB_HEAD_REF}

--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -59,31 +59,30 @@ jobs:
         apt --yes dist-upgrade
         apt --yes install wget curl gcc make m4 patch openssh-client unzip git libtest-simple-perl xz-utils g++ dejagnu
 
-    - name: Clone repo independently
+    - name: Chevah user setup
       run: |
-        git clone https://github.com/chevah/pythia.git
-        cd pythia
-        git checkout ${GITHUB_HEAD_REF}
+        useradd -g adm -s /bin/bash -m chevah
+        echo '%adm    ALL=NOPASSWD: ALL' > /etc/sudoers
+
+    - uses: actions/checkout@v4
 
     - name: Build Pythia
       timeout-minutes: 30
       run: |
-        cd pythia
-        ./build.sh build
+        chown -R chevah .
+        su chevah -c "./build.sh build"
 
     - name: Test Pythia
       timeout-minutes: 5
       run: |
-        cd pythia
-        ./build.sh test
+        su chevah -c "./build.sh test"
 
     - name: Test compat
       timeout-minutes: 5
       env:
         CODECOV_TOKEN: local
       run: |
-        cd pythia
-        ./build.sh compat
+        su chevah -c "./build.sh compat"
 
     # Using `~/` is problematic under Docker, use `/root/`.
     # Remove key in same step to avoid leaving it on disk if publishing fails.

--- a/build.sh
+++ b/build.sh
@@ -282,6 +282,7 @@ command_compat() {
     # Some tests might still fail due to causes not related to the new Python.
     execute ./pythia.sh deps
     execute ./pythia.sh test_normal
+    execute ./pythia.sh test_ci2
 
     execute popd
     echo "::endgroup::"

--- a/build.sh
+++ b/build.sh
@@ -286,6 +286,7 @@ command_compat() {
         echo "## Getting compat deps... ##"
         execute ./pythia.sh deps
         echo "## Running normal compat tests... ##"
+        # Why not test_normal? See https://github.com/chevah/compat/issues/691.
         execute ./pythia.sh test -vs normal
         if [ "${CI:-}" = "true" ]; then
             echo "## Running ci2 compat tests... ##"

--- a/build.sh
+++ b/build.sh
@@ -281,7 +281,7 @@ command_compat() {
     cp ../../"$DIST_DIR"/"$PYTHON_BUILD_VERSION.$PYTHIA_VERSION"/* cache/
     # Some tests might still fail due to causes not related to the new Python.
     execute ./pythia.sh deps
-    execute ./pythia.sh test_ci
+    execute ./pythia.sh test_normal
 
     execute popd
     echo "::endgroup::"

--- a/build.sh
+++ b/build.sh
@@ -274,10 +274,11 @@ command_compat() {
     execute cp ../../pythia.{conf,sh} ./
     # Patch compat to use the newly-built Python, then copy it to cache/.
     echo -e "\nPYTHON_CONFIGURATION=default@${new_python_conf}" >> pythia.conf
-    execute mkdir cache
-    execute cp -r ../"$PYTHON_BUILD_DIR" cache/
     # Make sure everything is done from scratch in the current dir.
     unset CHEVAH_CACHE CHEVAH_BUILD
+    # Copy dist file to local cache, if existing.
+    execute mkdir cache
+    cp ../../"$DIST_DIR"/"$PYTHON_BUILD_VERSION.$PYTHIA_VERSION"/* cache/
     # Some tests might still fail due to causes not related to the new Python.
     execute ./pythia.sh deps
     execute ./pythia.sh test_ci

--- a/build.sh
+++ b/build.sh
@@ -275,20 +275,22 @@ command_compat() {
         echo "## Unsetting CHEVAH_CACHE and CHEVAH_BUILD... ##"
         unset CHEVAH_CACHE CHEVAH_BUILD
         # Copy over current pythia stuff, as some changes might require it.
-        echo "## Patching compat code ot use current pythia version... ##"
+        echo "## Patching compat code to use current pythia version... ##"
         execute cp ../../pythia.{conf,sh} ./
         # Patch compat to use the current's branch version.
         echo -e "\nPYTHON_CONFIGURATION=default@${new_python_ver}" >>pythia.conf
-        # Copy dist file to local cache, if existing.
         execute mkdir cache
+        # Copy dist file to local cache, if existing. If not, maybe it's online.
         cp ../../"$DIST_DIR"/"$PYTHON_BUILD_VERSION.$PYTHIA_VERSION"/* cache/
         # Some tests could fail due to causes not related to the new Python.
         echo "## Getting compat deps... ##"
         execute ./pythia.sh deps
         echo "## Running normal compat tests... ##"
         execute ./pythia.sh test -vs normal
-        echo "## Running ci2 compat tests... ##"
-        execute ./pythia.sh test_ci2
+        if [ "${CI:-}" = "true" ]; then
+            echo "## Running ci2 compat tests... ##"
+            execute ./pythia.sh test_ci2
+        fi
     execute popd
     echo "::endgroup::"
 }

--- a/build.sh
+++ b/build.sh
@@ -260,7 +260,7 @@ command_test() {
 # shellcheck disable=SC2034 # Only used through compgen.
 help_text_compat="Run the test suite from chevah/compat master."
 command_compat() {
-    local new_python_conf="$PYTHON_BUILD_VERSION.$PYTHIA_VERSION"
+    local new_python_ver="$PYTHON_BUILD_VERSION.$PYTHIA_VERSION"
     execute pushd "$BUILD_DIR"
 
     # This is quite hackish, as compat is arm-twisted to use the local version.
@@ -268,22 +268,27 @@ command_compat() {
     echo "#### Running chevah's compat tests... ####"
     echo "## Removing any pre-existing compat code... ##"
     execute rm -rf compat/
+    echo "## Cloning compat's master branch... ##"
     execute git clone https://github.com/chevah/compat.git --depth=1 -b master
     execute pushd compat
-    # Copy over current pythia stuff, as some changes might require it.
-    execute cp ../../pythia.{conf,sh} ./
-    # Patch compat to use the newly-built Python, then copy it to cache/.
-    echo -e "\nPYTHON_CONFIGURATION=default@${new_python_conf}" >> pythia.conf
-    # Make sure everything is done from scratch in the current dir.
-    unset CHEVAH_CACHE CHEVAH_BUILD
-    # Copy dist file to local cache, if existing.
-    execute mkdir cache
-    cp ../../"$DIST_DIR"/"$PYTHON_BUILD_VERSION.$PYTHIA_VERSION"/* cache/
-    # Some tests might still fail due to causes not related to the new Python.
-    execute ./pythia.sh deps
-    execute ./pythia.sh test_normal
-    execute ./pythia.sh test_ci2
-
+        # Make sure everything is done from scratch in the current dir.
+        echo "## Unsetting CHEVAH_CACHE and CHEVAH_BUILD... ##"
+        unset CHEVAH_CACHE CHEVAH_BUILD
+        # Copy over current pythia stuff, as some changes might require it.
+        echo "## Patching compat code ot use current pythia version... ##"
+        execute cp ../../pythia.{conf,sh} ./
+        # Patch compat to use the current's branch version.
+        echo -e "\nPYTHON_CONFIGURATION=default@${new_python_ver}" >>pythia.conf
+        # Copy dist file to local cache, if existing.
+        execute mkdir cache
+        cp ../../"$DIST_DIR"/"$PYTHON_BUILD_VERSION.$PYTHIA_VERSION"/* cache/
+        # Some tests could fail due to causes not related to the new Python.
+        echo "## Getting compat deps... ##"
+        execute ./pythia.sh deps
+        echo "## Running normal compat tests... ##"
+        execute ./pythia.sh test -vs normal
+        echo "## Running ci2 compat tests... ##"
+        execute ./pythia.sh test_ci2
     execute popd
     echo "::endgroup::"
 }

--- a/pkg_checks.sh
+++ b/pkg_checks.sh
@@ -55,7 +55,7 @@ case "$OS" in
     linux*)
         if [ -x /sbin/apk ]; then
             # Assumes Alpine Linux 3.15.
-            CHECK_CMD=(apk info -q -e)
+            CHECK_CMD=(/sbin/apk info -q -e)
             PACKAGES="$APK_PKGS"
         elif [ -x /usr/bin/dpkg ]; then
             # Assumes Ubuntu Linux 16.04.

--- a/pythia.conf
+++ b/pythia.conf
@@ -1,7 +1,7 @@
 # When building a new major Python version, e.g. 3.11->3.12,
 # update this in advance (e.g. use "default@3.12.0.deadbeef"),
 # and remove BUILD_ENV_* files (e.g. with `./build.sh clean -a`).
-PYTHON_CONFIGURATION="default@3.12.7.ac6595f"
+PYTHON_CONFIGURATION="default@3.12.7.bb41ace"
 # This is defined as a Bash array of options to be passed to commands.
 BASE_REQUIREMENTS=("chevah-brink==1.0.15" "paver==1.3.4")
 # Use our private PyPi server instead of the default one set in pythia.sh.
@@ -9,6 +9,6 @@ PIP_INDEX_URL="https://bin.chevah.com:20443/pypi/simple"
 # Use our production server instead of the GitHub releases set by default.
 BINARY_DIST_URI="https://bin.chevah.com:20443/production"
 # For testing packages, make sure this one is the last uncommented instance:
-BINARY_DIST_URI="https://bin.chevah.com:20443/testing"
+#BINARY_DIST_URI="https://bin.chevah.com:20443/testing"
 # This directory is used by the Python runtime.
 CHEVAH_BUILD_DIR="build-py3"


### PR DESCRIPTION
Scope
-----

Fixes #47 


Changes
-------

Re-added compat series of tests, both `normal` and `test_ci2` (to account for https://github.com/chevah/compat/issues/691).

Docker builds and tests are now done under a regular `chevah` user, which is needed for elevated compat tests.


Testing
-------

Automated.

Please review changes and the GHA output.